### PR TITLE
fix: resolve five Elasticsearch indexing and search issues

### DIFF
--- a/src/Api/Controllers/SearchController.php
+++ b/src/Api/Controllers/SearchController.php
@@ -26,6 +26,7 @@ use Flarum\Group\Group;
 use Flarum\Http\RequestUtil;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Tags\Tag;
 use Flarum\User\User;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
@@ -224,6 +225,14 @@ class SearchController extends ListDiscussionsController
         $subQuery = BoolQuery::create()
             ->add(TermQuery::create('is_private', 'false'))
             ->add(TermsQuery::create('groups', $groups->toArray()));
+
+        if ($this->extensionEnabled('flarum-tags') && !empty($filters['tag'])) {
+            $slugs  = is_array($filters['tag']) ? $filters['tag'] : explode(',', $filters['tag']);
+            $tagIds = Tag::query()->whereIn('slug', $slugs)->pluck('id')->toArray();
+            if (!empty($tagIds)) {
+                $query->add(TermsQuery::create('tags', $tagIds), 'filter');
+            }
+        }
 
         if ($this->extensionEnabled('fof-byobu') && $actor->exists) {
             $byobuQuery = BoolQuery::create()

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -87,7 +87,7 @@ class BuildCommand extends Command
                 'index' => $index,
                 'body'  => [
                     'settings' => [
-                        'index.max_ngram_diff' => 10,
+                        'index.max_ngram_diff' => 7,
                         'analysis'             => [
                             'analyzer' => [
                                 'flarum_analyzer' => [
@@ -105,7 +105,7 @@ class BuildCommand extends Command
                             'filter' => [
                                 'partial_search_filter' => [
                                     'type'        => 'ngram',
-                                    'min_gram'    => 1,
+                                    'min_gram'    => 3,
                                     'max_gram'    => 10,
                                     'token_chars' => ['letter', 'digit', 'symbol'],
                                 ],

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -142,6 +142,9 @@ class BuildCommand extends Command
             $seeded = null;
 
             while ($continueAt !== null) {
+                $rangeFrom = max(1, $continueAt - 1000);
+                $rangeTo   = $continueAt;
+
                 if ($this->option('seed-missing')) {
                     $response = (new Builder($client))
                         ->index($index)
@@ -149,8 +152,8 @@ class BuildCommand extends Command
                         ->addQuery(
                             (new BoolQuery())
                             ->add((new RangeQuery('rawId'))
-                                ->gte($continueAt - 1000)
-                                ->lte($continueAt))
+                                ->gte($rangeFrom)
+                                ->lte($rangeTo))
                             ->add(TermQuery::create('type', $seeder->type()))
                         )
                         ->search();
@@ -161,7 +164,7 @@ class BuildCommand extends Command
                 /** @var Collection $collection */
                 $collection = $seeder->query()
                     ->latest('id')
-                    ->whereBetween('id', [$continueAt - 1000, $continueAt])
+                    ->whereBetween('id', [$rangeFrom, $rangeTo])
                     ->when($this->option('max-id'), function ($query, $id) {
                         $query->where('id', '<=', $id);
                     })
@@ -169,11 +172,19 @@ class BuildCommand extends Command
                     ->get();
 
                 $min = $collection->min('id');
-                $continueAt = $min && $min > 2 ? $min - 1 : null;
 
-                $queue->pushOn(Job::$onQueue, new SavingJob($collection, $seeder));
+                if ($this->option('seed-missing') && $collection->isEmpty()) {
+                    // All docs in this range are already indexed; advance past the range bottom.
+                    $continueAt = $rangeFrom > 2 ? $rangeFrom - 1 : null;
+                } else {
+                    $continueAt = $min && $min > 2 ? $min - 1 : null;
+                }
 
-                $this->info("Pushed into the index, type: {$seeder->type()}, amount: {$collection->count()}.");
+                if ($collection->isNotEmpty()) {
+                    $queue->pushOn(Job::$onQueue, new SavingJob($collection, $seeder));
+                }
+
+                $this->info("IDs {$rangeFrom}–{$rangeTo} | type: {$seeder->type()} | queued: {$collection->count()}.");
 
                 $total += $collection->count();
 
@@ -188,7 +199,7 @@ class BuildCommand extends Command
                 }
             }
 
-            $this->info("Pushed a total of $total into the index.");
+            $this->info("Queued a total of $total {$seeder->type()} for indexing.");
         }
     }
 

--- a/src/Seeders/CommentSeeder.php
+++ b/src/Seeders/CommentSeeder.php
@@ -76,7 +76,6 @@ class CommentSeeder extends Seeder
             'id'              => $this->type().':'.$model->id,
             'rawId'           => $model->id,
             'content'         => $model->content,
-            'content_partial' => $model->content,
             'created_at'      => $model->created_at?->toAtomString(),
             'updated_at'      => $model->edited_at?->toAtomString(),
             'is_private'      => $model->is_private,

--- a/src/Seeders/CommentSeeder.php
+++ b/src/Seeders/CommentSeeder.php
@@ -50,6 +50,7 @@ class CommentSeeder extends Seeder
     {
         $events->listen([
             Core\Posted::class,
+            Core\Revised::class
         ], function ($event) use ($callable) {
             $callable($event->post);
         });

--- a/src/Seeders/DiscussionSeeder.php
+++ b/src/Seeders/DiscussionSeeder.php
@@ -80,7 +80,6 @@ class DiscussionSeeder extends Seeder
             'id'              => $this->type().':'.$model->id,
             'rawId'           => $model->id,
             'content'         => $model->title,
-            'content_partial' => $model->title,
             'created_at'      => $model->created_at?->toAtomString(),
             'updated_at'      => $model->last_posted_at?->toAtomString(),
             'is_private'      => $model->is_private,


### PR DESCRIPTION
## Summary

- **Tag filter ignored** — navigating to `/t/{tag}?q=…` returned results from all tags because the `tag` filter was never applied to the ES query. Added a `TermsQuery` on the `tags` field using IDs resolved from the provided slugs.
- **Unused `content_partial` field** — both seeders stored content twice (once in `content`, once in `content_partial`). The partial field was never queried. Removed from both seeders; existing indices clean up on next `--recreate`.
- **Ngram `min_gram=1`** — single- and double-character ngram tokens were indexed but can never be matched (Flarum enforces a 3-character minimum query length). Changed `min_gram` from 1 to 3 and corrected `max_ngram_diff` to 7.
- **`--seed-missing` stops early** — when all documents in a range were already indexed, the empty collection set `continueAt` to null, aborting before scanning lower ID ranges. Now advances past the range bottom instead. Also clamps `rangeFrom` to 1 to prevent negative ID ranges.
- **Post edits not re-indexed** — `CommentSeeder` only listened to `Post\Event\Posted`. Added `Post\Event\Revised` so edited post content is reflected in search results.

## Deployment note

`--recreate` is required after deploying. The ngram analysis settings change cannot be applied to an existing index — the index must be rebuilt from scratch.

```bash
php flarum blomstra:search:index --recreate
```

## Test plan

- [ ] Search within a tag (`/t/{tag}?q=…`) returns only discussions from that tag
- [ ] Editing a post body updates the search result
- [ ] `--seed-missing` scans all ID ranges, including those fully covered by the existing index
- [ ] Index size is reduced after `--recreate` (fewer ngram tokens, no `content_partial`)
- [ ] No 500 on sort by `popular` / `unpopular` (separate PR)